### PR TITLE
Added details for LED and diode orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Features:
 
 There's no wrong order for the YamPAD assembly with the exception of the Arduino/OLED/ResetButton. Here I will suggest an order because I found more comfortable to solder the components this way.
 
-1. Start with soldering the **WS2812 LEDs**. Start by applying solder to a pad, then heat it up while adding the component, finally solder the remaining pads.
+1. Start with soldering the **WS2812 LEDs**. Start by applying solder to a pad, then heat it up while adding the component, finally solder the remaining pads. 
 2. Now add the **0805 100nF caps**. Use the same technique as before.
 3. Add the **1N4148 diodes**.
 4. Add the **CPG151101S11 Kailh PCB sockets**.
@@ -100,6 +100,7 @@ There's no wrong order for the YamPAD assembly with the exception of the Arduino
 
 #### Step 1: WS2812 assembly
 
+<p align="left">The LEDs have a direction, this is indicated by a small cut out corner showing a triangle on the LED itself that must align with a corner indicated on the PCB as a visible corner angle. Top left on images below.</p>
 <p align="center">
 <img src="img/assembly/step1-a.jpg" alt="Step 1-a" width="250"/>
 <img src="img/assembly/step1-b.jpg" alt="Step 1-b" width="250"/>
@@ -115,6 +116,7 @@ There's no wrong order for the YamPAD assembly with the exception of the Arduino
 
 #### Step 3: Diodes assembly
 
+<p align="left">The diodes have a direction, the side indicated by the line on the diode must align to the closed side of the shape on the PCB. Left on the three images below.</p>
 <p align="center">
 <img src="img/assembly/step3-a.jpg" alt="Step 3-a" width="250"/>
 <img src="img/assembly/step3-b.jpg" alt="Step 3-b" width="250"/>
@@ -149,7 +151,7 @@ There's no wrong order for the YamPAD assembly with the exception of the Arduino
 
 ## Firmware
 
-For now the firmware is available through mattdibi's [QMK firmware repository fork](https://github.com/mattdibi/qmk_firmware/tree/yampad).
+For now the firmware is available through mattdibi's [QMK firmware repository fork](https://github.com/mattdibi/qmk_firmware/tree/yampad), making sure you checkout the yampad branch.
 
 Make example for this keyboard (after setting up your build environment):
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Features:
 
 There's no wrong order for the YamPAD assembly with the exception of the Arduino/OLED/ResetButton. Here I will suggest an order because I found more comfortable to solder the components this way.
 
-1. Start with soldering the **WS2812 LEDs**. Start by applying solder to a pad, then heat it up while adding the component, finally solder the remaining pads. 
+1. Start with soldering the **WS2812 LEDs**. Start by applying solder to a pad, then heat it up while adding the component, finally solder the remaining pads.
 2. Now add the **0805 100nF caps**. Use the same technique as before.
 3. Add the **1N4148 diodes**.
 4. Add the **CPG151101S11 Kailh PCB sockets**.


### PR DESCRIPTION
I am a newbie for electronics, but it was not obvious to me (mostly for the LEDs) what the orientation was supposed to be, which resulted in me having to desolder half of them, which was not fun. Adding the small details in the description can save someone like me some time in preparing their board.

Also a small change from the discussion that also came up for me, that was to checkout the yampad branch of qmk.